### PR TITLE
Overhead Widget Component가 캐릭터의 조준과 HitScanWeapon에 사용되는 ECC_Visibilit…

### DIFF
--- a/Source/LBlaster/Character/LBlasterCharacter.cpp
+++ b/Source/LBlaster/Character/LBlasterCharacter.cpp
@@ -180,6 +180,7 @@ ALBlasterCharacter::ALBlasterCharacter(const FObjectInitializer& ObjectInitializ
 	OverheadWidgetComponent->SetWidgetSpace(EWidgetSpace::World);
 	OverheadWidgetComponent->SetDrawAtDesiredSize(true);
 	OverheadWidgetComponent->SetCastShadow(false);
+	OverheadWidgetComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Ignore);
 
 	static ConstructorHelpers::FClassFinder<UOverheadWidget> OverheadWidgetClassRef(TEXT("/Script/UMGEditor.WidgetBlueprint'/Game/LBlaster/UI/HUD/WBP_OverheadWidget.WBP_OverheadWidget_C'"));
 	if (OverheadWidgetClassRef.Class)


### PR DESCRIPTION
…y에 대해 Ignore하도록 설정해 캐릭터로 인식되지 않도록 함